### PR TITLE
Add financial indicators, small cleanup

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-from _stock_datasets import create_datasets, PriceSeriesDataset
+from .dataset import create_datasets, PriceSeriesDataset

--- a/src/_stock_datasets.py
+++ b/src/_stock_datasets.py
@@ -180,7 +180,7 @@ def create_datasets(
         root: str = "../data/clean",
         fixed_scaling: list[tuple[int, float]] = None,
         feature_indices: list[int] = None,
-        add_windowed_avgs: bool = False,
+        add_indicators: bool = False,
         **kwargs
 ) -> tuple[PriceSeriesDataset, PriceSeriesDataset, PriceSeriesDataset]:
     """
@@ -193,7 +193,7 @@ def create_datasets(
     :param root: The root directory to load the data from.
     :param fixed_scaling: A list of tuples of feature index and scaling factor.
     :param feature_indices: The indices of the features to use.
-    :param add_windowed_avgs: Whether to add windowed averages to the features.
+    :param add_indicators: Whether to add windowed averages to the features.
     :param kwargs: Additional keyword arguments to pass to create_splits.
 
     :return: A tuple of PriceSeriesDataset objects for the train, valid, and test sets.
@@ -214,7 +214,7 @@ def create_datasets(
 
     # TODO - Augment feature data here i.e. - financial indicators, one-hot encoding, etc.
     # Add simple moving averages
-    if add_windowed_avgs:
+    if add_indicators:
         adj_close = all_features[:, 5]
         windows = [5, 10, 20]
         sma_features = compute_sma(adj_close, windows=windows)
@@ -245,7 +245,7 @@ def run():
         val_size=0.15,
         fixed_scaling = [(7, 3000.), (8, 12.), (9, 31.)],
         feature_indices=[i for i in range(10)],
-        add_windowed_avgs=True
+        add_indicators=True
     )
 
     # Once we have the datasets, we can create DataLoader objects

--- a/src/_stock_datasets.py
+++ b/src/_stock_datasets.py
@@ -11,11 +11,14 @@ We export the following functions and classes via __init__.py:
 Example importing from top level:
     from src import create_datasets, PriceSeriesDataset
 """
+from datetime import datetime
+
 import numpy as np
 import torch as th
 from torch.utils.data import DataLoader, Dataset
 
-from src.indicators import compute_sma, compute_ema
+from src.indicators import compute_sma, compute_ema, compute_pct_b, compute_macd, compute_momentum, compute_rsi, \
+    compute_relative_volume
 
 
 class PriceSeriesDataset(Dataset):
@@ -34,6 +37,12 @@ class PriceSeriesDataset(Dataset):
     targets: th.Tensor
     """The targets of the dataset"""
 
+    close_idx: int
+    """The index of the close price column"""
+
+    price_features: list[int]
+    """The indices of the price features to normalize"""
+
     seq_len: int
     """The sequence length of the dataset windows"""
 
@@ -50,10 +59,10 @@ class PriceSeriesDataset(Dataset):
             self,
             features: th.Tensor,
             targets: th.Tensor,
+            price_features: list[int],
             close_idx: int = 5,
             seq_len: int = 10,
             t_0: float = None,
-            price_features: list[int] = None,
     ):
         """
         Initialize the dataset with the given features and targets.
@@ -68,9 +77,12 @@ class PriceSeriesDataset(Dataset):
         # Seq len can't be greater than the number of features
         assert seq_len <= features.shape[0], "Sequence length must be less than the number of features"
         assert seq_len > 0, "Sequence length must be greater than 0"
+        assert price_features is not None, "Price features must be specified"
 
         # We normalize price values by the first value of adj_close (col 5)
-        price_features = price_features if price_features is not None else [1, 2, 3, 4, 5]
+        self.close_idx = close_idx
+        self.price_features = price_features
+        # price_features = price_features if price_features is not None else [1, 2, 3, 4, 5]
         features[:, price_features] = features[:, price_features] / features[0, close_idx]
 
         # Don't use the last window as it will have no target
@@ -143,35 +155,51 @@ def load_symbol(
 def create_splits(
         features: th.Tensor,
         targets: th.Tensor,
-        train_size: float = 0.75,
-        val_size: float = 0.15,
         seq_len: int = 10,
+        train_start: str = "2020-10-18 00:00:00",
+        valid_start: str = "2023-10-18 00:00:00",
+        test_start: str = "2024-04-18 00:00:00",
+        test_end: str = "2024-10-18 00:00:00",
+        price_features: list[int] = None,
+        **kwargs # Swallow unused arguments
 ) -> tuple[PriceSeriesDataset, PriceSeriesDataset, PriceSeriesDataset]:
     """
     Split the data into train/valid/test sets and create DataLoader objects.
 
     :param features: The features to split.
     :param targets: The targets to split.
-    :param train_size: The size of the training set.
-    :param val_size: The size of the validation set.
     :param seq_len: The sequence length of the dataset windows.
+    :param train_start: The start date for the training set.
+    :param valid_start: The start date for the validation set.
+    :param test_start: The start date for the test set.
+    :param test_end: The end date for the test set.
+    :param price_features: The indices of the price features to normalize.
     :return: A tuple of DataLoader objects for the train, valid, and test sets.
     """
-    # Get counts for splits
-    n_rows = features.shape[0]
-    n_train, n_val = int(n_rows * train_size), int(n_rows * val_size)
-    n_test = n_rows - n_train - n_val
+    # Convert dates to timestamps for slicing
+    train_start_ts = datetime.fromisoformat(train_start).timestamp()
+    valid_start_ts = datetime.fromisoformat(valid_start).timestamp()
+    test_start_ts = datetime.fromisoformat(test_start).timestamp()
+    test_end_ts = datetime.fromisoformat(test_end).timestamp()
 
-    x_train, x_valid, x_test = th.split(features, [n_train, n_val, n_test])
-    y_train, y_valid, y_test = th.split(targets, [n_train, n_val, n_test])
+    # Split the targets
+    train_mask = (features[:, 0] >= train_start_ts) & (features[:, 0] < valid_start_ts)
+    valid_mask = (features[:, 0] >= valid_start_ts) & (features[:, 0] < test_start_ts)
+    test_mask = (features[:, 0] >= test_start_ts) & (features[:, 0] <= test_end_ts)
 
-    # Create the datasets
+    x_train, y_train = features[train_mask], targets[train_mask]
+    x_valid, y_valid = features[valid_mask], targets[valid_mask]
+    x_test, y_test = features[test_mask], targets[test_mask]
+
+    # TODO We should log the distribution of the targets here across the splits
+
     t_0 = x_train[0, 0].item()
+    price_features = [1, 2, 3, 4, 5] if price_features is None else price_features
 
     return (
-        PriceSeriesDataset(x_train, y_train, seq_len=seq_len),
-        PriceSeriesDataset(x_valid, y_valid, seq_len=seq_len, t_0=t_0),
-        PriceSeriesDataset(x_test, y_test, seq_len=seq_len, t_0=t_0)
+        PriceSeriesDataset(x_train, y_train, seq_len=seq_len, price_features=price_features),
+        PriceSeriesDataset(x_valid, y_valid, seq_len=seq_len, t_0=t_0, price_features=price_features),
+        PriceSeriesDataset(x_test, y_test, seq_len=seq_len, t_0=t_0, price_features=price_features)
     )
 
 
@@ -212,14 +240,35 @@ def create_datasets(
 
     all_features = all_features[:, feature_indices]
 
-    # TODO - Augment feature data here i.e. - financial indicators, one-hot encoding, etc.
-    # Add simple moving averages
+    n_features = all_features.shape[1]
     if add_indicators:
         adj_close = all_features[:, 5]
-        windows = [5, 10, 20]
-        sma_features = compute_sma(adj_close, windows=windows)
-        ema_features = compute_ema(adj_close, windows=windows)
-        all_features = th.cat([all_features, sma_features, ema_features], dim=1)
+        ma_windows = [5, 10, 20]
+
+        # Various indicators, we add 10 in total n_features -1 + 10 to
+        sma_features = compute_sma(adj_close, windows=ma_windows) # Cols n_features x len(ma_windows)
+        ema_features = compute_ema(adj_close, windows=ma_windows) # Cols
+        pct_b = compute_pct_b(adj_close)
+        macd_h = compute_macd(adj_close)
+        momentum = compute_momentum(adj_close)
+        rsi = compute_rsi(adj_close)
+        r_vols = compute_relative_volume(all_features[:, 6])
+
+        all_features = th.cat([
+            all_features,
+            sma_features,
+            ema_features,
+            pct_b,
+            macd_h,
+            momentum,
+            rsi,
+            r_vols
+        ], dim=1)
+
+        # 1:5 are open/high/low/close, adj_close so we add them and the moving averages
+        price_features = [i+1 for i in range(5)] + [n_features + i for i in range(6)]
+        kwargs["price_features"] = price_features
+
 
     # Create the splits using the specified sequence length
     train_data, valid_data, test_data = create_splits(
@@ -241,8 +290,6 @@ def run():
         "atnf",
         root="../data/clean",
         seq_len=10,
-        train_size=0.75,
-        val_size=0.15,
         fixed_scaling = [(7, 3000.), (8, 12.), (9, 31.)],
         feature_indices=[i for i in range(10)],
         add_indicators=True

--- a/src/dataset/__init__.py
+++ b/src/dataset/__init__.py
@@ -1,0 +1,2 @@
+from _dataset_utils import create_datasets
+from _priceseriesdataset import PriceSeriesDataset

--- a/src/dataset/_priceseriesdataset.py
+++ b/src/dataset/_priceseriesdataset.py
@@ -1,0 +1,95 @@
+import torch as th
+from torch.utils.data import Dataset
+
+
+class PriceSeriesDataset(Dataset):
+    """
+    A simple Dataset class for loading our using the torch APIs
+
+    For simplicity, expects that the features are already segmented into windows
+    of the desired sequence length. This could be adjusted in the future to allow
+    the sequence length to be a parameter of the SequenceDataset class itself
+    to abstract away the windowing process.
+    """
+
+    features: th.Tensor
+    """The features of the dataset"""
+
+    targets: th.Tensor
+    """The targets of the dataset"""
+
+    close_idx: int
+    """The index of the close price column"""
+
+    price_features: list[int]
+    """The indices of the price features to normalize"""
+
+    seq_len: int
+    """The sequence length of the dataset windows"""
+
+    feature_dim: int
+    """The size of a single feature vector in the dataset"""
+
+    t_0: float
+    """The first time value in the dataset, a UNIX timestamp"""
+
+    time_idx: th.Tensor
+    """The time index of the dataset"""
+
+    def __init__(
+            self,
+            features: th.Tensor,
+            targets: th.Tensor,
+            price_features: list[int],
+            close_idx: int = 5,
+            seq_len: int = 10,
+            t_0: float = None,
+    ):
+        """
+        Initialize the dataset with the given features and targets.
+
+        :param features: The time series features for the dataset.
+        :param targets: The targets for the dataset at each time step.
+        :param close_idx: The index of the close price column.
+        :param seq_len: The sequence length of the dataset windows.
+        :param t_0: The first time value in the dataset.
+        :param price_features: The indices of the price features to normalize.
+        """
+        # Seq len can't be greater than the number of features
+        assert seq_len <= features.shape[0], "Sequence length must be less than the number of features"
+        assert seq_len > 0, "Sequence length must be greater than 0"
+        assert price_features is not None, "Price features must be specified"
+
+        self.close_idx = close_idx
+        self.time_idx = features[:, 0].clone()
+
+        # Don't use the last window as it will have no target
+        self.t_0 = t_0 if t_0 is not None else self.time_idx[0].item()
+
+        # We subtract the first time value to get a relative time index starting at 0
+        self.features = self.__create_seq_windows(features, seq_len, self.t_0)
+        self.targets = targets[seq_len:]
+        self.feature_dim = self.features.shape[-1]
+
+    @staticmethod
+    def __create_seq_windows(
+            features: th.Tensor,
+            seq_len: int,
+            time_offset: float
+    ) -> th.Tensor:
+        """
+        Subtracts the first time value to get a relative time index.
+
+        :param features: The features to create windows for.
+        :param seq_len: The sequence length of the windows.
+        :param time_offset: The first time value in the dataset.
+        :return: A tensor of windows of the given sequence
+        """
+        features[:, 0] = (features[:, 0] - time_offset) / 86400  # seconds in a day
+        return features.unfold(0, seq_len, 1)[:-1].transpose(1, 2)
+
+    def __len__(self):
+        return self.features.shape[0]
+
+    def __getitem__(self, idx):
+        return self.features[idx], self.targets[idx]

--- a/src/indicators/__init__.py
+++ b/src/indicators/__init__.py
@@ -1,0 +1,1 @@
+from ._indicators import compute_ema, compute_sma

--- a/src/indicators/__init__.py
+++ b/src/indicators/__init__.py
@@ -1,1 +1,2 @@
-from ._indicators import compute_ema, compute_sma
+from ._indicators import compute_ema, compute_sma, compute_macd, compute_pct_b, compute_rsi, compute_momentum, \
+    compute_relative_volume

--- a/src/indicators/_indicators.py
+++ b/src/indicators/_indicators.py
@@ -127,8 +127,10 @@ def compute_momentum(prices: th.Tensor, window: int = 10) -> th.Tensor:
     assert prices.shape[0] > window, "Prices must have more data than the window size"
 
     # Compute momentum
-    momentum = th.full_like(prices, fill_value=th.nan)
-    momentum[window:] = (prices[window:] - prices[:-window]) / prices[:-window]
+    normed_prices = prices / prices[0]
+
+    momentum = th.full_like(normed_prices, fill_value=th.nan)
+    momentum[window:] = (normed_prices[window:] / normed_prices[:-window]) - 1
     return momentum.unsqueeze(1)
 
 def compute_rsi(prices: th.Tensor, window: int = 14) -> th.Tensor:
@@ -157,7 +159,7 @@ def run_example():
     # Run a simple example to test the functions
     # a random tensor of prices for 100 days, all strictly between 0 and 100
     th.manual_seed(42)
-    prices = th.rand(100) * 100
+    prices = th.rand(100)
 
     windows = [10, 20, 30]
     ema = compute_ema(prices, windows)

--- a/src/indicators/_indicators.py
+++ b/src/indicators/_indicators.py
@@ -1,0 +1,78 @@
+"""
+Indicators for averages on torch tensors - e.g. SMA, EMA
+"""
+
+import torch as th
+
+
+def compute_sma(prices: th.Tensor, windows: list[int] = None) -> th.Tensor:
+    """
+    Compute the simple moving averages for a given set of prices.
+
+    Dates without enough data will be filled with NaN. Simple moving averages
+    are window based average over a sequence of prices. The windows will be
+    computed for each window size in the list.
+
+    :param prices: A tensor of T prices T
+    :param windows: A list of W window sizes to compute the averages for
+    :return: A tensor of simple moving averages T x W
+    """
+    windows = windows if windows is not None else [5, 10, 20]
+    smas = th.full(size=(prices.shape[0], len(windows)), fill_value=th.nan)
+
+    cum_prices = prices.cumsum(dim=0)
+
+    for ix, w in enumerate(windows):
+        smas[w - 1:, ix] = prices.unfold(0, w, 1).mean(1)
+
+        # Use a rolling average over the nan values
+        smas[:w - 1, ix] =  cum_prices[:w - 1]/ th.arange(1, w)
+
+    # Normalize the SMA values by the initial price
+    smas = smas / prices[0]
+
+    return smas
+
+
+def compute_ema(prices: th.Tensor, windows: list[int] = None) -> th.Tensor:
+    """
+    Compute the exponential moving averages for a given set of prices.
+
+    Unlike SMA, the values for EMA can start at the beginning of the time series.
+    Exponential moving averages are weighted window based average over a sequence
+    of prices. The windows will be computed for each window size in the list.
+
+    :param prices: A tensor of prices T x 1
+    :param windows: A list of W window sizes to compute the averages for
+    :return: A tensor of exponential moving averages T x W
+    """
+    windows = th.tensor(windows) if windows is not None else th.tensor([5, 10, 20])
+
+    emas = th.zeros(prices.shape[0], len(windows))
+    alphas = 2 / (windows + 1)
+
+    # Set the initial price and iterate
+    emas[0] = prices[0]
+    for t in range(1, prices.shape[0]):
+        emas[t] = alphas * prices[t] + (1 - alphas) * emas[t - 1]
+
+    # Normalize the EMA values by the initial price
+    emas = emas / prices[0]
+
+    return emas
+
+
+def run_example():
+    # Run a simple example to test the functions
+    prices = th.tensor([1.4, 1.2, 1.4, 1.6, 1.8, 2.0])
+    windows = [2, 3, 4]
+    ema = compute_ema(prices, windows)
+    print(ema)
+
+    sma = compute_sma(prices, windows)
+    print(sma)
+    pass
+
+
+if __name__ == '__main__':
+    run_example()

--- a/src/indicators/_indicators.py
+++ b/src/indicators/_indicators.py
@@ -26,10 +26,10 @@ def compute_sma(prices: th.Tensor, windows: list[int] = None) -> th.Tensor:
         smas[w - 1:, ix] = prices.unfold(0, w, 1).mean(1)
 
         # Use a rolling average over the nan values
-        smas[:w - 1, ix] =  cum_prices[:w - 1]/ th.arange(1, w)
+        smas[:w - 1, ix] = cum_prices[:w - 1] / th.arange(1, w)
 
-    # Normalize the SMA values by the initial price
-    smas = smas / prices[0]
+    # # Normalize the SMA values by the initial price
+    # smas = smas / prices[0]
 
     return smas
 
@@ -56,22 +56,120 @@ def compute_ema(prices: th.Tensor, windows: list[int] = None) -> th.Tensor:
     for t in range(1, prices.shape[0]):
         emas[t] = alphas * prices[t] + (1 - alphas) * emas[t - 1]
 
-    # Normalize the EMA values by the initial price
-    emas = emas / prices[0]
+    # # Normalize the EMA values by the initial price
+    # emas = emas / prices[0]
 
     return emas
 
 
+def compute_macd(
+        prices: th.Tensor,
+        slow: int = 26,
+        fast: int = 12,
+        signal: int = 9
+) -> th.Tensor:
+    """
+    Compute the moving average convergence divergence (MACD) histogram.
+
+    The MACD is computed as the difference between the slow and fast moving averages.
+    We then take the difference between the MACD and the signal line, which gives
+    us the MACD histogram.
+
+    :param prices: The prices to compute the MACD for
+    :param slow: The slow moving average window, default is 26
+    :param fast: The fast moving average window, default is 12
+    :param signal: The signal line window, default is 9
+    :return: A tensor of MACD histogram values T x 1
+    """
+    # Get the 12, 26 day smas and the signal EMA
+    smas = compute_sma(prices, [slow, fast])
+    signal_line = compute_ema(prices, [signal])
+
+    # Compute the histogram values
+    macd_h = smas[:, 1] - smas[:, 0] - signal_line[:, 0]
+    return macd_h.unsqueeze(1)
+
+
+def compute_pct_b(prices: th.Tensor, sma_size: int = 20) -> th.Tensor:
+    """
+    Compute the percentage B indicator for a given set of prices.
+
+    :param prices: The prices to compute the indicator for
+    :param sma_size: The simple moving average window size, default is 20
+    :return: A tensor of percentage B values T x 1
+    """
+    assert sma_size > 1, "SMA size must be greater than 1"
+    assert prices.shape[0] > sma_size, "Prices must have more data than the SMA size"
+
+    # Compute the sma
+    sma_20 = compute_sma(prices, [sma_size])[:, 0]
+
+    # Grab the sd, but we'll only be defined from the sma_size - 1
+    sd = th.full_like(prices, fill_value=th.nan)
+    sd[sma_size - 1:] = prices.unfold(0, sma_size, 1).std(1)
+
+    # Upper and Lower Bands are sma +/- the sd
+    upper_band = sma_20 + 2 * sd
+    lower_band = sma_20 - 2 * sd
+
+    # We compute %B similar to min-max scaling, subtracting the lower band
+    return ((prices - lower_band) / (upper_band - lower_band)).unsqueeze(1)
+
+def compute_momentum(prices: th.Tensor, window: int = 10) -> th.Tensor:
+    """
+    Compute the momentum indicator for a given set of prices.
+
+    :param prices: The prices to compute the indicator for
+    :param window: The window size for the momentum indicator
+    :return: A tensor of momentum values T x 1
+    """
+    assert window > 1, "Window size must be greater than 1"
+    assert prices.shape[0] > window, "Prices must have more data than the window size"
+
+    # Compute momentum
+    momentum = th.full_like(prices, fill_value=th.nan)
+    momentum[window:] = (prices[window:] - prices[:-window]) / prices[:-window]
+    return momentum.unsqueeze(1)
+
+def compute_rsi(prices: th.Tensor, window: int = 14) -> th.Tensor:
+
+    result = th.full_like(prices, fill_value=th.nan).unsqueeze(1)
+    # Compute the daily differences
+    deltas = prices[1:] - prices[:-1]
+
+    # We can clip up and down days
+    gain_days, loss_days = deltas.clone().clip(min=0), deltas.clone().clip(max=0).abs()
+    # gain_days = gain_days.clip(min=0)
+    # loss_days =loss_days.clip(max=0)
+
+    # Compute n-day EMA for gains and losses
+    ema_gain = compute_ema(gain_days, [window])
+    ema_loss = compute_ema(loss_days, [window])
+
+    # Finally compute the RSI
+    result[1:] = 1 - (1/ (1 + (ema_gain / ema_loss)))
+    # We need to cap at 100
+    result.clip(max=1)
+    return result
+
+
 def run_example():
     # Run a simple example to test the functions
-    prices = th.tensor([1.4, 1.2, 1.4, 1.6, 1.8, 2.0])
-    windows = [2, 3, 4]
-    ema = compute_ema(prices, windows)
-    print(ema)
+    # a random tensor of prices for 100 days, all strictly between 0 and 100
+    th.manual_seed(42)
+    prices = th.rand(100) * 100
 
+    windows = [10, 20, 30]
+    ema = compute_ema(prices, windows)
     sma = compute_sma(prices, windows)
-    print(sma)
-    pass
+    pct_b = compute_pct_b(prices, sma_size=3)
+    macd = compute_macd(prices)
+    moment = compute_momentum(prices, window=10)
+    rsi = compute_rsi(prices, window=14)
+    # Make sure we can concat all of these features
+
+    features = th.cat([prices.unsqueeze(1), ema, sma, pct_b, macd, moment, rsi], dim=-1)
+    print(features)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds 11 financial indicators to the datasets before splitting into train/valid/test
- Simple & Exponential moving averages
- %B
- MACD Histogram
- Momentum (ROC)
- Relative Volume
- Relative Strength Index (RSI)

These will be computed and added to the dataset as part of the `create_datasets` call
- Added default date ranges for train/valid/test instead of percentage splits
- Simplified the args to create datasets, should just be a simple call
- Added a fixed scaling option for the Year/Month/Day columns
    - Mostly related to time2vec things, can move out if needed


If there are any other indicators you'd like to see added please let me know and we can get it rolled into this PR.

Lastly - please yell at me if this is too much. 